### PR TITLE
Support for tags/keywords

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,11 @@ To support MetaWeblog, you must first create a class that implements the IMetaWe
       throw new NotImplementedException();
     }
 
+    public Task<Tag[]> GetTagsAsync(string blogid, string username, string password)
+    {
+      throw new NotImplementedException();
+    }
+
     public Page GetPage(string blogid, string pageid, string username, string password)
     {
       throw new NotImplementedException();

--- a/src/WilderMinds.MetaWeblog.Tests/MethodFacts.cs
+++ b/src/WilderMinds.MetaWeblog.Tests/MethodFacts.cs
@@ -180,6 +180,7 @@ namespace MetaWeblog.Tests
       Assert.True(!result.Descendants("fault").Any(), "Should not contain a fault");
       Assert.True(result.Descendants("name").Any(s => s.Value == "title"), "Should contain a Post");
       Assert.True(result.Descendants("value").Any(s => s.Value == "This is a post"), "Should contain a post title");
+      Assert.True(result.Descendants("name").Any(s => s.Value == "mt_keywords"), "Should contain post tags");
     }
 
     [Fact]
@@ -258,6 +259,12 @@ namespace MetaWeblog.Tests
       <name>date_created_gmt</name>
       <value>
        <dateTime.iso8601>20160414T08:19:00</dateTime.iso8601>
+      </value>
+     </member>
+     <member>
+      <name>mt_keyword</name>
+      <value>
+       <string>addPostTag1,addPostTag2</string>
       </value>
      </member>
     </struct>

--- a/src/WilderMinds.MetaWeblog.Tests/MethodFacts.cs
+++ b/src/WilderMinds.MetaWeblog.Tests/MethodFacts.cs
@@ -120,6 +120,38 @@ namespace MetaWeblog.Tests
     }
 
     [Fact]
+    public async Task ShouldReturnTag()
+    {
+      var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<methodCall>
+ <methodName>wp.getTags</methodName>
+ <params>
+  <param>
+   <value>
+    <string>0123456789ABCDEF</string>
+   </value>
+  </param>
+  <param>
+   <value>
+    <string>TestUser</string>
+   </value>
+  </param>
+  <param>
+   <value>
+    <string>testPassword</string>
+   </value>
+  </param>
+ </params>
+</methodCall>";
+
+      var result = await IssueMethod(xml);
+      Assert.True(!result.Descendants("fault").Any(), "Should not contain a fault");
+      Assert.True(result.Descendants("name").Where(s => s.Value == "name").Count() == 2, "Should contain two tags");
+      Assert.True(result.Descendants("value").Any(s => s.Value == "C#"), "Should contain a tag named 'C#'");
+      Assert.True(result.Descendants("value").Any(s => s.Value == "Razor"), "Should contain a tag named 'Razor'");
+    }
+
+    [Fact]
     public async Task ShouldReturnPost()
     {
       var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>

--- a/src/WilderMinds.MetaWeblog.Tests/Properties/launchSettings.json
+++ b/src/WilderMinds.MetaWeblog.Tests/Properties/launchSettings.json
@@ -16,7 +16,7 @@
       }
     },
     "test": {
-      "commandName": "test",
+      "commandName": "Project",
       "sdkVersion": "dnx-coreclr-win-x64.1.0.0"
     }
   }

--- a/src/WilderMinds.MetaWeblog.Tests/TestMetaWeblogService.cs
+++ b/src/WilderMinds.MetaWeblog.Tests/TestMetaWeblogService.cs
@@ -55,6 +55,7 @@ namespace MetaWeblog.Tests
         permalink = "/123",
         title = "This is a post",
         userid = "swildermuth",
+        mt_keywords = "getPostTag1,getPostTag2",
         categories = new string[] { "usda" }
       });
     }

--- a/src/WilderMinds.MetaWeblog.Tests/TestMetaWeblogService.cs
+++ b/src/WilderMinds.MetaWeblog.Tests/TestMetaWeblogService.cs
@@ -36,6 +36,15 @@ namespace MetaWeblog.Tests
       });
     }
 
+    public Task<Tag[]> GetTagsAsync(string blogid, string username, string password)
+    {
+      return Task.FromResult(new Tag[]
+      {
+        new Tag() { name = "C#" },
+        new Tag() { name = "Razor" },
+      });
+    }
+
     public Task<Post> GetPostAsync(string postid, string username, string password)
     {
       return Task.FromResult(new Post()

--- a/src/WilderMinds.MetaWeblog/IMetaWeblogProvider.cs
+++ b/src/WilderMinds.MetaWeblog/IMetaWeblogProvider.cs
@@ -22,6 +22,8 @@ namespace WilderMinds.MetaWeblog
 
     Task<int> AddCategoryAsync(string key, string username, string password, NewCategory category);
 
+    Task<Tag[]> GetTagsAsync(string blogid, string username, string password);
+
     Task<MediaObjectInfo> NewMediaObjectAsync(string blogid, string username, string password, MediaObject mediaObject);
 
     Task<Page> GetPageAsync(string blogid, string pageid, string username, string password);

--- a/src/WilderMinds.MetaWeblog/MetaWeblogService.cs
+++ b/src/WilderMinds.MetaWeblog/MetaWeblogService.cs
@@ -77,6 +77,13 @@ namespace WilderMinds.MetaWeblog
       return await _provider.GetCategoriesAsync(blogid, username, password);
     }
 
+    [XmlRpcMethod("wp.getTags")]
+    public async Task<Tag[]> GetTagsAsync(string blogid, string username, string password)
+    {
+      _logger.LogInformation($"MetaWeblog:GetTagsAsync is called");
+      return await _provider.GetTagsAsync(blogid, username, password);
+    }
+
     [XmlRpcMethod("metaWeblog.newMediaObject")]
     public async Task<MediaObjectInfo> NewMediaObjectAsync(string blogid, string username, string password, MediaObject mediaObject)
     {

--- a/src/WilderMinds.MetaWeblog/Structs.cs
+++ b/src/WilderMinds.MetaWeblog/Structs.cs
@@ -26,6 +26,11 @@ namespace WilderMinds.MetaWeblog
     public string description;
   }
 
+  public class Tag
+  {
+    public string name;
+  }
+
   public class Enclosure
   {
     public int length;

--- a/src/WilderMinds.MetaWeblog/Structs.cs
+++ b/src/WilderMinds.MetaWeblog/Structs.cs
@@ -49,6 +49,7 @@ namespace WilderMinds.MetaWeblog
     public string userid;
     public string wp_slug;
     public string mt_excerpt;
+    public string mt_keywords;
     public string link;
   }
 


### PR DESCRIPTION
Windows/Open Live Writer supports the usage of tags/keyworkds in posts. This PR allows the library to provide this functionality.

It's probably a breaking change since there is a new method to the IMetaWeblogProvider interface.