### PR TITLE
Adds missing Post attributes

### DIFF
--- a/src/WilderMinds.MetaWeblog/Structs.cs
+++ b/src/WilderMinds.MetaWeblog/Structs.cs
@@ -52,6 +52,8 @@ namespace WilderMinds.MetaWeblog
     public string mt_keywords;
     public string link;
     public string wp_post_thumbnail;
+    public int mt_allow_comments;
+    public string mt_basename;
   }
 
   public class Source


### PR DESCRIPTION
The Post struct is missing a couple of attributes as part of MetaWeblog. You can see these attributes posted from OpenLiveWriter.

The mt_allow_comments is added when you go to all options:

![image](https://user-images.githubusercontent.com/1742685/224140735-f4ec3f3f-6b09-40a0-802b-b1e61b42005a.png)

I'm not sure what the mt_basename is used for, seems the same as wp_slug but it is also passed up in the XML.